### PR TITLE
updating calq to pass through the events original timestamp

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -16,12 +16,14 @@ var reject = require('reject');
  */
 
 exports.track = function(track){
+  var timestamp = track.timestamp();
   return reject({
     actor: track.userId() || track.sessionId(),
     properties: properties(track),
     write_key: this.settings.writeKey,
     action_name: track.event(),
-    ip_address: track.ip()
+    ip_address: track.ip(),
+    timestamp: timestamp && timestamp.toISOString()
   });
 };
 
@@ -35,10 +37,12 @@ exports.track = function(track){
  */
 
 exports.alias = function(alias){
+  var timestamp = alias.timestamp();
   return reject({
     old_actor: alias.previousId(),
     write_key: this.settings.writeKey,
-    new_actor: alias.userId()
+    new_actor: alias.userId(),
+    timestamp: timestamp && timestamp.toISOString()
   });
 };
 
@@ -52,10 +56,12 @@ exports.alias = function(alias){
  */
 
 exports.identify = function(identify){
+  var timestamp = identify.timestamp();
   return reject({
     actor: identify.userId() || identify.sessionId(),
     properties: traits(identify),
-    write_key: this.settings.writeKey
+    write_key: this.settings.writeKey,
+    timestamp: timestamp && timestamp.toISOString()
   });
 };
 

--- a/test/fixtures/alias.json
+++ b/test/fixtures/alias.json
@@ -2,11 +2,13 @@
   "input": {
     "type": "alias",
     "previousId": "previous-id",
-    "userId": "user-id"
+    "userId": "user-id",
+    "timestamp": "2014"
   },
   "output": {
     "old_actor": "previous-id",
     "write_key": "0e116d3930b329831f146716c3667dfe",
-    "new_actor": "user-id"
+    "new_actor": "user-id",
+    "timestamp": "2014-01-01T00:00:00.000Z"
   }
 }

--- a/test/fixtures/identify-basic.json
+++ b/test/fixtures/identify-basic.json
@@ -2,6 +2,7 @@
   "input": {
     "type": "identify",
     "userId": "user-id",
+    "timestamp": "2014",
     "traits": {
       "avatar": "https://some.url/avatar.jpg",
       "country": "US",
@@ -16,6 +17,7 @@
   "output": {
     "actor": "user-id",
     "write_key": "0e116d3930b329831f146716c3667dfe",
+    "timestamp": "2014-01-01T00:00:00.000Z",
     "properties": {
       "$image_url": "https://some.url/avatar.jpg",
       "$country": "US",

--- a/test/fixtures/identify.json
+++ b/test/fixtures/identify.json
@@ -1,5 +1,6 @@
 {
   "userId": "user-id",
+  "timestamp": "2014",
   "traits": {
     "fat": 0.02,
     "firstName": "John",

--- a/test/fixtures/identify.out.json
+++ b/test/fixtures/identify.out.json
@@ -1,5 +1,6 @@
 {
   "actor": "user-id",
+  "timestamp": "2014-01-01T00:00:00.000Z",
   "properties": {
     "fat": 0.02,
     "firstName": "John",

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -3,10 +3,12 @@
     "type": "track",
     "event": "my-event",
     "userId": "user-id",
+    "timestamp": "2014",
     "properties": {}
   },
   "output": {
     "actor": "user-id",
+    "timestamp": "2014-01-01T00:00:00.000Z",
     "properties": {},
     "write_key": "0e116d3930b329831f146716c3667dfe",
     "action_name": "my-event"

--- a/test/fixtures/track-full.json
+++ b/test/fixtures/track-full.json
@@ -3,6 +3,7 @@
     "type": "track",
     "event": "my-event",
     "userId": "user-id",
+    "timestamp": "2014",
     "properties": {
       "revenue": 19.19,
       "currency": "USD"
@@ -28,6 +29,7 @@
     "write_key": "0e116d3930b329831f146716c3667dfe",
     "action_name": "my-event",
     "ip_address": "10.0.0.1",
+    "timestamp": "2014-01-01T00:00:00.000Z",
     "properties": {
       "$device_agent": "user-agent",
       "$device_resolution": "500x400",


### PR DESCRIPTION
Calq wasn't passing through events' timestamps with the event so Calq was giving events timestamps when they arrived at Calq. This was a problem when replaying events to Calq because the original timestamp wouldn't be sent so all the events appeared to occurred during the time of replay.

I added the  Calq timestamp property from [here](https://calq.io/docs/client/http) and mapped it to each event's timestamp property.
