### PR TITLE
Add page and screen + fix tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,11 +2,12 @@
 /**
  * Module dependencies.
  */
-
+var fmt = require('util').format;
 var integration = require('segmentio-integration');
+var is = require('is');
 var mapper = require('./mapper');
 var tick = setImmediate;
-var is = require('is');
+
 
 /**
  * Expose `Calq`
@@ -29,11 +30,16 @@ var Calq = module.exports = integration('Calq')
  */
 
 Calq.prototype.track = function(payload, fn){
+  var self = this
   return this
     .post('/track')
     .type('json')
     .send(payload)
-    .end(this.handle(fn));
+    .end(this.handle(function(err, res) {
+      if (err) return fn(err);
+      if (res.body.status === "rejected") return fn(new Error(res.body.error));
+      fn(null, res);
+    }));
 };
 
 /**
@@ -68,5 +74,9 @@ Calq.prototype.identify = function(payload, fn){
     .post('/profile')
     .type('json')
     .send(payload)
-    .end(this.handle(fn));
+    .end(this.handle(function(err, res) {
+      if (err) return fn(err);
+      if (res.body.status === "rejected") return fn(new Error(res.body.error));
+      fn(null, res);
+    }));
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,11 +35,7 @@ Calq.prototype.track = function(payload, fn){
     .post('/track')
     .type('json')
     .send(payload)
-    .end(this.handle(function(err, res) {
-      if (err) return fn(err);
-      if (res.body.status === "rejected") return fn(new Error(res.body.error));
-      fn(null, res);
-    }));
+    .end(this.handle(fn));
 };
 
 /**
@@ -91,9 +87,5 @@ Calq.prototype.identify = function(payload, fn){
     .post('/profile')
     .type('json')
     .send(payload)
-    .end(this.handle(function(err, res) {
-      if (err) return fn(err);
-      if (res.body.status === "rejected") return fn(new Error(res.body.error));
-      fn(null, res);
-    }));
+    .end(this.handle(fn));
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,6 +43,23 @@ Calq.prototype.track = function(payload, fn){
 };
 
 /**
+ * Track Page or Screen view using within Calq. In Calq this is a call to Track
+ * with some extra special properties set (such as URL or screen name)
+ *
+ * @param {Track|Screen} payload
+ * @param {Function} fn
+ */
+
+Calq.prototype.screen =
+Calq.prototype.page = function(payload, fn){
+  return this
+    .post('/track')
+    .type('json')
+    .send(payload)  // Mapper will add the special params
+    .end(this.handle(fn));
+};
+
+/**
  * Alias a user from one id to the other. In Calq this is called Transfer.
  *
  * @param {Alias} alias

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -28,9 +28,12 @@ exports.track = function(track) {
  */
 
 exports.screen = function(screen) {
-  var payload = exports.page(screen);
+  var payload = createCommonPayload(screen, this.settings);
   payload.action_name = 'Screen View';
-
+  payload.properties.$view_name = screen.name();
+  del(payload.properties, 'name'); // Don't send twice
+  payload.properties = reject(payload.properties);
+  
   return reject(payload);
 };
 

--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -15,16 +15,47 @@ var reject = require('reject');
  * @return {Object} payload
  */
 
-exports.track = function(track){
-  var timestamp = track.timestamp();
-  return reject({
-    actor: track.userId() || track.sessionId(),
-    properties: properties(track),
-    write_key: this.settings.writeKey,
-    action_name: track.event(),
-    ip_address: track.ip(),
-    timestamp: timestamp && timestamp.toISOString()
-  });
+exports.track = function(track) {
+  return createCommonPayload(track, this.settings);
+};
+
+/**
+ * Maps a screen call. In Calq this is a call to Track
+ * with some extra properties set.
+ *
+ * @param {Screen} screen
+ * @return {Object} payload
+ */
+
+exports.screen = function(screen) {
+  var payload = exports.page(screen);
+  payload.action_name = 'Screen View';
+
+  return reject(payload);
+};
+
+/**
+ * Maps a page call. In Calq this is a call to Track
+ * with some extra properties set.
+ *
+ * @param {Page} page
+ * @return {Object} payload
+ */
+
+exports.page = function(page) {
+  // Same as track, but we need to add page specific info
+  var payload = createCommonPayload(page, this.settings);
+  payload.action_name = 'Page View';
+
+  // If not set then reject will clear these (e.g. a page view with no name given)
+  payload.properties.category = page.category();
+  payload.properties.$view_name = page.name();
+  payload.properties.$view_url = page.url();
+  del(payload.properties, 'name'); // Don't send twice
+  del(payload.properties, 'url'); // Don't send twice
+  payload.properties = reject(payload.properties);
+
+  return reject(payload);
 };
 
 /**
@@ -36,7 +67,7 @@ exports.track = function(track){
  * @return {Object} payload
  */
 
-exports.alias = function(alias){
+exports.alias = function(alias) {
   var timestamp = alias.timestamp();
   return reject({
     old_actor: alias.previousId(),
@@ -55,7 +86,7 @@ exports.alias = function(alias){
  * @return {Object} payload
  */
 
-exports.identify = function(identify){
+exports.identify = function(identify) {
   var timestamp = identify.timestamp();
   return reject({
     actor: identify.userId() || identify.sessionId(),
@@ -66,21 +97,39 @@ exports.identify = function(identify){
 };
 
 /**
- * Gets the properties to be sent with a track call.
+ * Gets the base properties to be sent with all track calls. Used by track, page and screen.
  *
  * @param {Track} track
  * @return {Object} properties
  */
 
-function properties(track){
-  var ret = track.properties();
-  ret.$device_agent = track.userAgent();
+function createCommonPayload(facade, settings) {
+  return reject({
+    timestamp: facade.timestamp() && facade.timestamp().toISOString(),
+    actor: facade.userId() || facade.sessionId(),
+    properties: properties(facade),
+    write_key: settings.writeKey,
+    action_name: facade.event(),
+    ip_address: facade.ip()
+  });
+}
 
-  var dimensions = resolution(track);
+/**
+ * Gets the user properties to be sent with a track call.
+ *
+ * @param {Track} track
+ * @return {Object} properties
+ */
+
+function properties(facade) {
+  var ret = facade.properties();
+  ret.$device_agent = facade.userAgent();
+
+  var dimensions = resolution(facade);
   if (dimensions) ret.$device_resolution = dimensions;
 
   // Campaign is mapped to special properties in Calq
-  var campaign = track.proxy('context.campaign');
+  var campaign = facade.proxy('context.campaign');
   if (campaign) {
     ret.$utm_campaign = campaign.name;
     ret.$utm_source = campaign.source;
@@ -90,13 +139,15 @@ function properties(track){
   }
 
   // Calq needs both currency and value together or neither
-  var saleCurrency = track.currency();
-  var saleValue = track.revenue();
-  if (saleCurrency != null && saleCurrency.length == 3 && !isNaN(saleValue)) {
-    ret.$sale_currency = saleCurrency;
-    ret.$sale_value = saleValue;
-    del(ret, 'currency'); // Don't send twice
-    del(ret, 'revenue');  // Don't send twice
+  if (facade.currency) {  // Used by page() and facade(), but page() won't have currency
+    var saleCurrency = facade.currency();
+    var saleValue = facade.revenue();
+    if (saleCurrency != null && saleCurrency.length == 3 && !isNaN(saleValue)) {
+      ret.$sale_currency = saleCurrency;
+      ret.$sale_value = saleValue;
+      del(ret, 'currency'); // Don't send twice
+      del(ret, 'revenue');  // Don't send twice
+    }
   }
 
   return reject(ret);
@@ -109,7 +160,7 @@ function properties(track){
  * @return {String} resolution  e.g. "300x540"
  */
 
-function resolution(facade){
+function resolution(facade) {
   var width = facade.proxy('context.screen.width');
   var height = facade.proxy('context.screen.height');
   if (isNaN(width) || width <= 0) return;
@@ -124,7 +175,7 @@ function resolution(facade){
  * @return {Object} traits
  */
 
-function traits(identify){
+function traits(identify) {
   return identify.traits({
     avatar: '$image_url',
     country: '$country',

--- a/test/fixtures/page-all.json
+++ b/test/fixtures/page-all.json
@@ -1,0 +1,16 @@
+{
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "properties": {},
+    "context": {}
+  },
+  "output": {
+    "actor": "user-id",
+    "properties": {},
+    "write_key": "0e116d3930b329831f146716c3667dfe",
+    "timestamp": "2014-01-01T00:00:00.000Z",
+    "action_name": "Page View"
+  }
+}

--- a/test/fixtures/page-categorized.json
+++ b/test/fixtures/page-categorized.json
@@ -1,0 +1,21 @@
+{
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "category": "Docs",
+    "properties": {
+      "url": "https://segment.io/docs/integrations/calq"
+    }
+  },
+  "output": {
+    "actor": "user-id",
+    "properties": {
+		"category": "Docs",
+		"$view_url": "https://segment.io/docs/integrations/calq"
+	},
+    "write_key": "0e116d3930b329831f146716c3667dfe",
+    "timestamp": "2014-01-01T00:00:00.000Z",
+    "action_name": "Page View"
+  }
+}

--- a/test/fixtures/page-named.json
+++ b/test/fixtures/page-named.json
@@ -1,0 +1,23 @@
+{
+  "input": {
+    "type": "page",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "category": "Docs",
+    "name": "Calq Integration",
+    "properties": {
+      "url": "https://segment.io/docs/integrations/calq"
+    }
+  },
+  "output": {
+    "actor": "user-id",
+    "properties": {
+		"$view_name": "Calq Integration",
+		"category": "Docs",
+		"$view_url": "https://segment.io/docs/integrations/calq"
+	},
+    "write_key": "0e116d3930b329831f146716c3667dfe",
+    "timestamp": "2014-01-01T00:00:00.000Z",
+    "action_name": "Page View"
+  }
+}

--- a/test/fixtures/screen-all.json
+++ b/test/fixtures/screen-all.json
@@ -1,0 +1,16 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "properties": {},
+    "context": {}
+  },
+  "output": {
+    "actor": "user-id",
+    "properties": {},
+    "write_key": "0e116d3930b329831f146716c3667dfe",
+    "timestamp": "2014-01-01T00:00:00.000Z",
+    "action_name": "Screen View"
+  }
+}

--- a/test/fixtures/screen-categorized.json
+++ b/test/fixtures/screen-categorized.json
@@ -1,0 +1,21 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "category": "Docs",
+    "properties": {
+      "property": true
+    }
+  },
+  "output": {
+    "actor": "user-id",
+    "properties": {
+		"category": "Docs",
+		"property": true
+	},
+    "write_key": "0e116d3930b329831f146716c3667dfe",
+    "timestamp": "2014-01-01T00:00:00.000Z",
+    "action_name": "Screen View"
+  }
+}

--- a/test/fixtures/screen-named.json
+++ b/test/fixtures/screen-named.json
@@ -1,0 +1,23 @@
+{
+  "input": {
+    "type": "screen",
+    "userId": "user-id",
+    "timestamp": "2014",
+    "category": "Docs",
+    "name": "Test Screen",
+    "properties": {
+      "property": true
+    }
+  },
+  "output": {
+    "actor": "user-id",
+    "properties": {
+		"$view_name": "Test Screen",
+		"category": "Docs",
+		"property": true
+	},
+    "write_key": "0e116d3930b329831f146716c3667dfe",
+    "timestamp": "2014-01-01T00:00:00.000Z",
+    "action_name": "Screen View"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -79,12 +79,13 @@ describe('Calq', function () {
         .expects(200, done);
     });
 
-    it('should error on an invalid write key', function(done){
+    it('should return error and 200 on an invalid write key', function(done){
       test
         .set({ writeKey: 'bad-key' })
         .track(helpers.track())
-        .expects(400)
-        .error('cannot POST /track (400)', done);
+        .expects({"status":"rejected","error":"The write_key \"bad-key\" did not match any known keys."})
+        .expects(200)
+        .error('The write_key \"bad-key\" did not match any known keys.', done);
     });
   });
 
@@ -102,8 +103,9 @@ describe('Calq', function () {
       test
         .set({ writeKey: 'bad-key' })
         .identify(json.input)
-        .expects(400)
-        .error('cannot POST /profile (400)', done);
+        .expects({'status':'rejected','error':'The write_key "bad-key" did not match any known keys.'})
+        .expects(200)
+        .error('The write_key "bad-key" did not match any known keys.', done);
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -79,13 +79,12 @@ describe('Calq', function () {
         .expects(200, done);
     });
 
-    it('should return error and 200 on an invalid write key', function(done){
+    it('should error on an invalid write key', function(done){
       test
         .set({ writeKey: 'bad-key' })
         .track(helpers.track())
-        .expects({"status":"rejected","error":"The write_key \"bad-key\" did not match any known keys."})
-        .expects(200)
-        .error('The write_key \"bad-key\" did not match any known keys.', done);
+        .expects(403)
+        .error('cannot POST /track (403)', done);
     });
   });
 
@@ -103,9 +102,8 @@ describe('Calq', function () {
       test
         .set({ writeKey: 'bad-key' })
         .identify(json.input)
-        .expects({'status':'rejected','error':'The write_key "bad-key" did not match any known keys.'})
-        .expects(200)
-        .error('The write_key "bad-key" did not match any known keys.', done);
+        .expects(403)
+        .error('cannot POST /profile (403)', done);
     });
   });
 
@@ -123,8 +121,8 @@ describe('Calq', function () {
       test
         .set({ writeKey: 'bad-key' })
         .alias(json.input)
-        .expects(400)
-        .error('cannot POST /transfer (400)', done);
+        .expects(403)
+        .error('cannot POST /transfer (403)', done);
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -127,4 +127,63 @@ describe('Calq', function () {
         .error('cannot POST /transfer (400)', done);
     });
   });
+
+  describe('.page()', function(){
+    it('should be able to track all pages', function(done){
+      var json = test.fixture('page-all');
+      test
+        .set(settings)
+        .page(json.input)
+        .sends(json.output)
+        .expects(200, done);
+    });
+  
+    it('should be able to track categorized pages', function(done){
+      var json = test.fixture('page-categorized');
+      test
+        .set(settings)
+        .page(json.input)
+        .sends(json.output)
+        .expects(200, done);
+    });
+
+    it('should be able to track named pages', function(done){
+      var json = test.fixture('page-named');
+      test
+        .set(settings)
+        .page(json.input)
+        .sends(json.output)
+        .expects(200, done);
+    });
+  });
+  
+  describe('.screen()', function(){
+    it('should be able to track all screens', function(done){
+      var json = test.fixture('screen-all');
+      test
+        .set(settings)
+        .screen(json.input)
+        .sends(json.output)
+        .expects(200, done);
+    });
+  
+    it('should be able to track categorized screens', function(done){
+      var json = test.fixture('screen-categorized');
+      test
+        .set(settings)
+        .screen(json.input)
+        .sends(json.output)
+        .expects(200, done);
+    });
+
+    it('should be able to track named screens', function(done){
+      var json = test.fixture('screen-named');
+      test
+        .set(settings)
+        .screen(json.input)
+        .sends(json.output)
+        .expects(200, done);
+    });
+  });
+
 });


### PR DESCRIPTION
Hey @sperand-io - can you take a look at this when you get a chance?

To recap, these are the changes included in this PR:
- Resolved the failing write_key validation tests due to changes in Calq's API response from 400 to 200 with status:rejected message
- Incorporated Calq's addition of the page and screen call including tests
